### PR TITLE
Fix obsolete swarm commands in upstart files.

### DIFF
--- a/ansible/roles/docker/templates/swarm_client_upstart.conf.j2
+++ b/ansible/roles/docker/templates/swarm_client_upstart.conf.j2
@@ -7,6 +7,6 @@ post-stop exec sleep 10
 script
 /usr/local/bin/swarm join \
   --addr={{ ansible_eth1['ipv4']['address'] }}:{{ docker_port }} \
-  --discovery {{ swarm_discovery_string }} \
+  {{ swarm_discovery_string }} \
 end script
 respawn

--- a/ansible/roles/docker_swarm/templates/docker_swarm_upstart.conf.j2
+++ b/ansible/roles/docker_swarm/templates/docker_swarm_upstart.conf.j2
@@ -13,6 +13,6 @@ script
 {% endif %}
     -H tcp://0.0.0.0:{{ docker_port }} \
     --strategy {{  packing_strategy }} \
-    --discovery {{ swarm_discovery_string }}
+    {{ swarm_discovery_string }}
 end script
 


### PR DESCRIPTION
swarm no longer requires the '--discovery' option to specify discovery endpoint.
